### PR TITLE
Small change to ensure downloads done in subdir

### DIFF
--- a/download_archaea.pl
+++ b/download_archaea.pl
@@ -7,8 +7,8 @@ use Bio::PrimarySeq;
 # create a directory
 unless (-d "archaea") {
 	mkdir "archaea";
-	chdir "archaea";
 }
+chdir "archaea";
 
 # get the assembly file
 if (-e "assembly_summary.txt") {

--- a/download_bacteria.pl
+++ b/download_bacteria.pl
@@ -7,8 +7,8 @@ use Bio::PrimarySeq;
 # create a directory
 unless (-d "bacteria") {
 	mkdir "bacteria";
-	chdir "bacteria";
 }
+chdir "bacteria";
 
 # get the assembly file
 if (-e "assembly_summary.txt") {

--- a/download_fungi.pl
+++ b/download_fungi.pl
@@ -7,8 +7,8 @@ use Bio::PrimarySeq;
 # create a directory
 unless (-d "fungi") {
         mkdir "fungi";
-        chdir "fungi";
 }
+chdir "fungi";
 
 # get the assembly file
 if (-e "assembly_summary.txt") {

--- a/download_protozoa.pl
+++ b/download_protozoa.pl
@@ -7,8 +7,8 @@ use Bio::PrimarySeq;
 # create a directory
 unless (-d "protozoa") {
         mkdir "protozoa";
-        chdir "protozoa";
 }
+chdir "protozoa";
 
 # get the assembly file
 if (-e "assembly_summary.txt") {

--- a/download_viral.pl
+++ b/download_viral.pl
@@ -7,9 +7,8 @@ use Bio::PrimarySeq;
 # create a directory
 unless (-d "viral") {
         mkdir "viral";
-        chdir "viral";
 }
-
+chdir "viral";
 
 # get the assembly file
 if (-e "assembly_summary.txt") {


### PR DESCRIPTION
Previously, if a subdirectory like bacteria already existed (if, say, the script were restarted), the downloads would be done at ".". This small change ensures they're always done in the subdirectory.
