### PR TITLE
check system() return code, use unlink() instead of system(rm ..)

### DIFF
--- a/download_archaea.pl
+++ b/download_archaea.pl
@@ -12,9 +12,10 @@ chdir "archaea";
 
 # get the assembly file
 if (-e "assembly_summary.txt") {
-	system("rm assembly_summary.txt");
+	unlink("assembly_summary.txt");
 }
-system("wget -q ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/archaea/assembly_summary.txt");
+system("wget -q ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/archaea/assembly_summary.txt") == 0
+    or die "failed: $?";
 
 unless (-e "assembly_summary.txt") {
 	warn "Unable to download assembly_summary.txt\n";
@@ -45,14 +46,16 @@ while(<IN>) {
 		my $fullpath = "$ftppath" . "/" . $aname . "_genomic.fna.gz";
 
 		# download
-		system("wget -q $fullpath");
+		system("wget -q $fullpath") == 0
+                    or die "failed: $?";
 		unless (-e "${aname}_genomic.fna.gz") {
 			warn "We don't have ${aname}_genomic.fna.gz, did download fail?";
 			next;
 		}
 
 		# gunzip
-		system("gunzip ${aname}_genomic.fna.gz");
+		system("gunzip ${aname}_genomic.fna.gz") == 0
+                    or die "failed: $?";
 		unless (-e "${aname}_genomic.fna") {
 			warn "We don't have ${aname}_genomic.fna, did gunzip fail?";
 			next;
@@ -81,7 +84,7 @@ while(<IN>) {
 		}
 
 		# remove original
-		system("rm ${aname}_genomic.fna");
+		unlink("${aname}_genomic.fna");
 
 	}
 }

--- a/download_bacteria.pl
+++ b/download_bacteria.pl
@@ -12,9 +12,10 @@ chdir "bacteria";
 
 # get the assembly file
 if (-e "assembly_summary.txt") {
-	system("rm assembly_summary.txt");
+	unlink("assembly_summary.txt");
 }
-system("wget -q ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/bacteria/assembly_summary.txt");
+system("wget -q ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/bacteria/assembly_summary.txt") == 0
+    or die "failed: $?";
 
 unless (-e "assembly_summary.txt") {
 	warn "Unable to download assembly_summary.txt\n";
@@ -45,14 +46,16 @@ while(<IN>) {
 		my $fullpath = "$ftppath" . "/" . $aname . "_genomic.fna.gz";
 
 		# download
-		system("wget -q $fullpath");
+		system("wget -q $fullpath") == 0
+                    or die "failed: $?";
 		unless (-e "${aname}_genomic.fna.gz") {
 			warn "We don't have ${aname}_genomic.fna.gz, did download fail?";
 			next;
 		}
 
 		# gunzip
-		system("gunzip ${aname}_genomic.fna.gz");
+		system("gunzip ${aname}_genomic.fna.gz") == 0
+                    or die "failed: $?";
 		unless (-e "${aname}_genomic.fna") {
 			warn "We don't have ${aname}_genomic.fna, did gunzip fail?";
 			next;
@@ -81,7 +84,7 @@ while(<IN>) {
 		}
 
 		# remove original
-		system("rm ${aname}_genomic.fna");
+		unlink("${aname}_genomic.fna");
 
 	}
 }

--- a/download_fungi.pl
+++ b/download_fungi.pl
@@ -12,9 +12,10 @@ chdir "fungi";
 
 # get the assembly file
 if (-e "assembly_summary.txt") {
-	system("rm assembly_summary.txt");
+	unlink("assembly_summary.txt");
 }
-system("wget -q ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/fungi/assembly_summary.txt");
+system("wget -q ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/fungi/assembly_summary.txt") == 0
+    or die "failed: $?";
 
 unless (-e "assembly_summary.txt") {
 	warn "Unable to download assembly_summary.txt\n";
@@ -45,14 +46,16 @@ while(<IN>) {
 		my $fullpath = "$ftppath" . "/" . $aname . "_genomic.fna.gz";
 
 		# download
-		system("wget -q $fullpath");
+		system("wget -q $fullpath") == 0
+                    or die "failed: $?";
 		unless (-e "${aname}_genomic.fna.gz") {
 			warn "We don't have ${aname}_genomic.fna.gz, did download fail?";
 			next;
 		}
 
 		# gunzip
-		system("gunzip ${aname}_genomic.fna.gz");
+		system("gunzip ${aname}_genomic.fna.gz") == 0
+                    or die "failed: $?";
 		unless (-e "${aname}_genomic.fna") {
 			warn "We don't have ${aname}_genomic.fna, did gunzip fail?";
 			next;
@@ -81,7 +84,7 @@ while(<IN>) {
 		}
 
 		# remove original
-		system("rm ${aname}_genomic.fna");
+		unlink("${aname}_genomic.fna");
 
 	}
 }

--- a/download_human.pl
+++ b/download_human.pl
@@ -9,7 +9,8 @@ use Bio::PrimarySeq;
 my $fa = "ftp://ftp.ensembl.org/pub/release-84/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz";
 
 # get the assembly file
-system("wget -q $fa");
+system("wget -q $fa") == 0
+    or die "failed: $?";
 
 # open the file
 my $fname = basename($fa);

--- a/download_protozoa.pl
+++ b/download_protozoa.pl
@@ -12,9 +12,10 @@ chdir "protozoa";
 
 # get the assembly file
 if (-e "assembly_summary.txt") {
-	system("rm assembly_summary.txt");
+	unlink("assembly_summary.txt");
 }
-system("wget -q ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/protozoa/assembly_summary.txt");
+system("wget -q ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/protozoa/assembly_summary.txt") == 0
+    or die "failed: $?";
 
 unless (-e "assembly_summary.txt") {
 	warn "Unable to download assembly_summary.txt\n";
@@ -45,14 +46,16 @@ while(<IN>) {
 		my $fullpath = "$ftppath" . "/" . $aname . "_genomic.fna.gz";
 
 		# download
-		system("wget -q $fullpath");
+		system("wget -q $fullpath") == 0
+                    or die "failed: $?";
 		unless (-e "${aname}_genomic.fna.gz") {
 			warn "We don't have ${aname}_genomic.fna.gz, did download fail?";
 			next;
 		}
 
 		# gunzip
-		system("gunzip ${aname}_genomic.fna.gz");
+		system("gunzip ${aname}_genomic.fna.gz") == 0
+                    or die "failed: $?";
 		unless (-e "${aname}_genomic.fna") {
 			warn "We don't have ${aname}_genomic.fna, did gunzip fail?";
 			next;
@@ -81,7 +84,7 @@ while(<IN>) {
 		}
 
 		# remove original
-		system("rm ${aname}_genomic.fna");
+		unlink("${aname}_genomic.fna");
 
 	}
 }

--- a/download_viral.pl
+++ b/download_viral.pl
@@ -12,9 +12,10 @@ chdir "viral";
 
 # get the assembly file
 if (-e "assembly_summary.txt") {
-	system("rm assembly_summary.txt");
+	unlink("assembly_summary.txt");
 }
-system("wget -q ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/viral/assembly_summary.txt");
+system("wget -q ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/viral/assembly_summary.txt") == 0
+    or die "failed: $?";
 
 unless (-e "assembly_summary.txt") {
 	warn "Unable to download assembly_summary.txt\n";
@@ -45,14 +46,16 @@ while(<IN>) {
 		my $fullpath = "$ftppath" . "/" . $aname . "_genomic.fna.gz";
 
 		# download
-		system("wget -q $fullpath");
+		system("wget -q $fullpath") == 0
+                    or die "failed: $?";
 		unless (-e "${aname}_genomic.fna.gz") {
 			warn "We don't have ${aname}_genomic.fna.gz, did download fail?";
 			next;
 		}
 
 		# gunzip
-		system("gunzip ${aname}_genomic.fna.gz");
+		system("gunzip ${aname}_genomic.fna.gz") == 0
+                    or die "failed: $?";
 		unless (-e "${aname}_genomic.fna") {
 			warn "We don't have ${aname}_genomic.fna, did gunzip fail?";
 			next;
@@ -81,7 +84,7 @@ while(<IN>) {
 		}
 
 		# remove original
-		system("rm ${aname}_genomic.fna");
+		unlink("${aname}_genomic.fna");
 
 	}
 }


### PR DESCRIPTION
cleanup, and check exit code whenever invoking external programs